### PR TITLE
fix: Changed status check from invoice to inv_item

### DIFF
--- a/app/models/invoice.rb
+++ b/app/models/invoice.rb
@@ -10,6 +10,8 @@ class Invoice < ApplicationRecord
   has_many :transactions
 
   def self.incomplete_invoices
-    where(status: "in progress")
+    joins(:invoice_items)
+      .where(invoice_items: { status: [1, 2] })
+      .distinct
   end
 end

--- a/spec/features/admin/index_spec.rb
+++ b/spec/features/admin/index_spec.rb
@@ -72,23 +72,33 @@ RSpec.describe "Admin", type: :feature do
         customer_2 = create(:customer)
         merchant = create(:merchant)
         invoices = Array.new
-        invoices.concat(create_list(:invoice, 3, status: "completed", customer: customer_1))
+        invoices.concat(create_list(:invoice, 3, status: "in progress", customer: customer_1))
         invoices.concat(create_list(:invoice, 3, status: "in progress", customer: customer_2))
         
-        invoices.each do |invoice|
+        invoices[0..1].each do |invoice|
           item = create(:item, merchant: merchant)
-          invoice_item = create(:invoice_item, invoice: invoice, item: item)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 0)
         end
-        
+        invoices[2..3].each do |invoice|
+          item = create(:item, merchant: merchant)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 1)
+        end
+        invoices[4..5].each do |invoice|
+          item = create(:item, merchant: merchant)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 2)
+        end
         visit admins_path
-        
+        save_and_open_page
         within "#incomplete_invoices" do
           expect(page).to_not have_content(invoices[0].id)
+          expect(page).to_not have_content(invoices[1].id)
+          expect(page).to have_content(invoices[2].id)
           expect(page).to have_content(invoices[3].id)
           expect(page).to have_content(invoices[4].id)
           expect(page).to have_content(invoices[5].id)
           # "And each invoice id links to that invoice's admin show page"
-          expect(page).to have_link("#{invoices[3].id}", href: "/admin/invoices/#{invoices[3].id}")
+          expect(page).to have_link("#{invoices[2].id}", href: "/admin/invoices/#{invoices[2].id}")
+          expect(page).to have_link("#{invoices[4].id}", href: "/admin/invoices/#{invoices[4].id}")
         end
       end
     end

--- a/spec/models/invoice_spec.rb
+++ b/spec/models/invoice_spec.rb
@@ -15,17 +15,25 @@ RSpec.describe Invoice, type: :model do
   describe "class methods" do
     it "#incomplete_invoices" do
       customer_1 = create(:customer)
-      customer_2 = create(:customer)
-      merchant = create(:merchant)
-      invoices = Array.new
-      invoices.concat(create_list(:invoice, 3, status: "completed", customer: customer_1))
-      invoices.concat(create_list(:invoice, 3, status: "in progress", customer: customer_2))
-      
-      invoices.each do |invoice|
-        item = create(:item, merchant: merchant)
-        invoice_item = create(:invoice_item, invoice: invoice, item: item)
-      end
-      expect(Invoice.incomplete_invoices).to eq([invoices[3],invoices[4],invoices[5]])
+        customer_2 = create(:customer)
+        merchant = create(:merchant)
+        invoices = Array.new
+        invoices.concat(create_list(:invoice, 3, status: "in progress", customer: customer_1))
+        invoices.concat(create_list(:invoice, 3, status: "in progress", customer: customer_2))
+        
+        invoices[0..1].each do |invoice|
+          item = create(:item, merchant: merchant)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 0)
+        end
+        invoices[2..3].each do |invoice|
+          item = create(:item, merchant: merchant)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 1)
+        end
+        invoices[4..5].each do |invoice|
+          item = create(:item, merchant: merchant)
+          invoice_item = create(:invoice_item, invoice: invoice, item: item, status: 2)
+        end
+      expect(Invoice.incomplete_invoices).to eq([invoices[2],invoices[3],invoices[4],invoices[5]])
     end
   end
 end


### PR DESCRIPTION
We had mistakenly keyed the "Incomplete Invoices" based on the Invoice status. I later realized that this list of invoices is triggered by having any InvoiceItem associations that didn't have a status of "shipped". Model test and Feature test has been corrected for this.